### PR TITLE
feat: Local file storage, file preview/edit, security hardening & public version history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn.lock
 
 # custom folder/files
 ui-prototypes
+backend/public/uploads/

--- a/backend/controllers/v1/adminController.js
+++ b/backend/controllers/v1/adminController.js
@@ -2,6 +2,7 @@ const UserModel = require("../../models/userModels");
 const DataModel = require("../../models/dataModels");
 const ActivityLog = require("../../models/activityLogModel");
 const AdminSettings = require("../../models/adminModels");
+const FileModel = require("../../models/fileModels");
 const logger = require("../../utils/loggerUtility");
 
 /**
@@ -181,7 +182,7 @@ exports.getUserDetails = async (req, res) => {
 exports.updateUser = async (req, res) => {
   try {
     const { id } = req.params;
-    const { username, email, role, isActive, isVerified, fileUploadEnabled, fileSizeLimit } = req.body;
+    const { username, email, role, isActive, isVerified, fileUploadEnabled, fileSizeLimit, localFileUploadEnabled } = req.body;
 
     // Prevent admin from removing their own admin role
     if (req.admin._id.toString() === id && role && role !== 'admin') {
@@ -201,6 +202,9 @@ exports.updateUser = async (req, res) => {
     // File upload settings
     if (typeof fileUploadEnabled === 'boolean') {
       updateData.fileUploadEnabled = fileUploadEnabled;
+    }
+    if (typeof localFileUploadEnabled === 'boolean') {
+      updateData.localFileUploadEnabled = localFileUploadEnabled;
     }
     if (fileSizeLimit !== undefined && fileSizeLimit !== null) {
       // Validate file size limit (should be in bytes, min 0.1MB, max 100MB)
@@ -704,11 +708,7 @@ exports.getOverviewStats = async (req, res) => {
       ActivityLog.distinct('userId', { action: 'login', createdAt: { $gte: last7d } }),
       ActivityLog.distinct('userId', { action: 'login', createdAt: { $gte: last30d } }),
       DataModel.countDocuments({ isDeleted: { $ne: true } }),
-      DataModel.aggregate([
-        { $match: { isDeleted: { $ne: true } } },
-        { $unwind: { path: '$files', preserveNullAndEmptyArrays: true } },
-        { $count: 'total' }
-      ]).then(result => result[0]?.total || 0).catch(() => 0),
+      FileModel.countDocuments({ isDeleted: false }),
       UserModel.countDocuments({ createdAt: { $gte: last24h } }),
       UserModel.countDocuments({ createdAt: { $gte: last7d } }),
       UserModel.countDocuments({ createdAt: { $gte: last30d } })
@@ -731,7 +731,7 @@ exports.getOverviewStats = async (req, res) => {
           total: totalDocuments
         },
         files: {
-          total: totalFiles[0]?.total || 0
+          total: totalFiles
         },
       }
     });

--- a/backend/controllers/v1/adminController.js
+++ b/backend/controllers/v1/adminController.js
@@ -708,7 +708,7 @@ exports.getOverviewStats = async (req, res) => {
       ActivityLog.distinct('userId', { action: 'login', createdAt: { $gte: last7d } }),
       ActivityLog.distinct('userId', { action: 'login', createdAt: { $gte: last30d } }),
       DataModel.countDocuments({ isDeleted: { $ne: true } }),
-      FileModel.countDocuments({ isDeleted: false }),
+      FileModel.countDocuments({ isDeleted: { $ne: true } }),
       UserModel.countDocuments({ createdAt: { $gte: last24h } }),
       UserModel.countDocuments({ createdAt: { $gte: last7d } }),
       UserModel.countDocuments({ createdAt: { $gte: last30d } })

--- a/backend/controllers/v1/fileController.js
+++ b/backend/controllers/v1/fileController.js
@@ -4,6 +4,8 @@ const googleDriveService = require("../../services/googleDriveService");
 const localStorageService = require("../../services/localStorageService");
 const logger = require("../../utils/loggerUtility");
 const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
 
 /**
  * ========================================
@@ -147,6 +149,33 @@ exports.uploadFile = async (req, res) => {
       });
     }
 
+    // --- MIME type / extension allowlist ---
+    // Only well-known, safe file types are accepted. Executables (.sh, .php, .exe…) are blocked.
+    const ALLOWED_EXTENSIONS = new Set([
+      'jpg', 'jpeg', 'png', 'gif', 'svg', 'webp',
+      'pdf',
+      'txt', 'md', 'html', 'css', 'js', 'json', 'xml', 'yaml', 'yml', 'csv',
+      'zip', 'tar', 'gz',
+      'mp4', 'mp3', 'wav',
+      'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+    ]);
+    const ALLOWED_MIME_PREFIXES = [
+      'image/', 'text/', 'application/pdf',
+      'application/json', 'application/xml',
+      'application/zip', 'application/gzip',
+      'application/msword', 'application/vnd.openxmlformats',
+      'application/vnd.ms-', 'audio/', 'video/',
+    ];
+
+    const fileExt = (req.file.originalname.split('.').pop() || '').toLowerCase();
+    const isMimeAllowed = ALLOWED_MIME_PREFIXES.some(prefix => req.file.mimetype.startsWith(prefix));
+    if (!ALLOWED_EXTENSIONS.has(fileExt) || !isMimeAllowed) {
+      return res.status(400).json({
+        success: false,
+        message: `File type '${fileExt}' is not allowed. Please upload a permitted file type.`,
+      });
+    }
+
     // Double-check file size against user's limit (already validated in validateFile, but extra safety)
     const userFileSizeLimit = user.fileSizeLimit || (1 * 1024 * 1024); // Default 1MB
     const allowed_for_slug = process.env.ALLOW_FILE_LIMIT;
@@ -165,28 +194,26 @@ exports.uploadFile = async (req, res) => {
     
     if (localFileUploadEnabled) {
       try {
-        console.log('📤 Uploading to Local Disk');
+        logger.logInfo?.('Uploading to Local Disk', { userId: user._id, fileName: req.file.originalname });
         const result = await localStorageService.uploadFile(req.file.buffer, req.file.originalname);
-        
-        console.log(`✅ File stored on Local Disk: ${result.fileName}`);
+
+        // Pre-generate the Mongo ID so downloadUrl can be set in a single save()
+        const fileId = new mongoose.Types.ObjectId();
 
         const newFile = new FileModel({
+          _id: fileId,
           owner: user._id,
           name: req.file.originalname,
           storageMethod: 'local_disk',
           localPath: result.filePath,
-          url: result.url, // Relative URL for public access
-          downloadUrl: `/api/v1/files/${result.fileName}`, // Placeholder or actual download route
+          url: result.url,
+          downloadUrl: `/api/v1/files/${fileId}`,
           type: req.file.mimetype,
           size: result.size || req.file.size,
           uploadedAt: new Date(),
         });
 
         const savedFile = await newFile.save();
-        
-        // Update download URL with the real ID
-        savedFile.downloadUrl = `/api/v1/files/${savedFile._id}`;
-        await savedFile.save();
 
         return res.status(200).json({
           success: true,
@@ -208,7 +235,7 @@ exports.uploadFile = async (req, res) => {
             message: "Failed to upload to local storage: " + localError.message,
           });
         }
-        console.log('⚠️ Local upload failed, falling back to Google Drive');
+        logger.logError(new Error('Local upload failed, falling back to Google Drive'), req, { controller: 'fileController', function: 'uploadFile', level: 'warning', context: { userId: req?.user?._id } });
       }
     }
 
@@ -221,8 +248,6 @@ exports.uploadFile = async (req, res) => {
         });
       }
 
-      console.log('📤 Uploading to Google Drive (OAuth)');
-      
       // Get user's folder name (default: "CodeShare-Uploads")
       const folderName = user.fileUploadFolder || "CodeShare-Uploads";
       
@@ -233,8 +258,6 @@ exports.uploadFile = async (req, res) => {
         user._id.toString(), // Pass user ID for OAuth token
         folderName // Pass folder name to use/create folder
       );
-
-      console.log(`✅ File stored in Google Drive (FREE): ${result.fileId}`);
 
       // Save file metadata to separate FileModel (independent from documents)
       const newFile = new FileModel({
@@ -317,9 +340,33 @@ exports.downloadFile = async (req, res) => {
     // Check storage method
     if (file.storageMethod === 'local_disk') {
       try {
-        console.log('📥 Downloading from Local Disk');
-        
-        if (!file.localPath || !fs.existsSync(file.localPath)) {
+        if (!file.localPath) {
+          return res.status(404).json({
+            success: false,
+            message: "Local file not found on disk",
+          });
+        }
+
+        // --- Path Traversal Guard ---
+        // Ensure the stored path resolves within the expected uploads directory.
+        const uploadsRoot = path.resolve(localStorageService.getUploadPath());
+        const resolvedPath = path.resolve(file.localPath);
+        if (!resolvedPath.startsWith(uploadsRoot + path.sep) && resolvedPath !== uploadsRoot) {
+          logger.logError(new Error('Path traversal attempt blocked'), req, {
+            controller: 'fileController',
+            function: 'downloadFile',
+            resourceType: 'file',
+            resourceId: fileId,
+            level: 'critical',
+            context: { userId: req?.user?._id, storedPath: file.localPath }
+          });
+          return res.status(403).json({
+            success: false,
+            message: "Access denied",
+          });
+        }
+
+        if (!fs.existsSync(resolvedPath)) {
           return res.status(404).json({
             success: false,
             message: "Local file not found on disk",
@@ -334,10 +381,8 @@ exports.downloadFile = async (req, res) => {
         res.setHeader('Content-Disposition', `${disposition}; filename="${file.name}"`);
         
         // Stream file to client
-        const fileStream = fs.createReadStream(file.localPath);
+        const fileStream = fs.createReadStream(resolvedPath);
         fileStream.pipe(res);
-        
-        console.log('✅ File streamed from Local Disk');
         return;
       } catch (localError) {
         logger.logError(localError, req, {
@@ -364,8 +409,6 @@ exports.downloadFile = async (req, res) => {
 
     // Download from Google Drive using OAuth (user's Drive)
     try {
-      console.log('📥 Downloading from Google Drive (OAuth)');
-      
       const stream = await googleDriveService.downloadFile(file.googleDriveFileId, user._id.toString());
       
       const isPreview = req.query.preview === 'true';
@@ -378,8 +421,6 @@ exports.downloadFile = async (req, res) => {
 
       // Stream file to client
       stream.pipe(res);
-
-      console.log('✅ File streamed from Google Drive (FREE)');
     } catch (driveError) {
       logger.logError(driveError, req, {
         controller: 'fileController',
@@ -443,9 +484,7 @@ exports.deleteFile = async (req, res) => {
     // Delete from Local Disk
     if (file.storageMethod === 'local_disk' && file.localPath) {
       try {
-        console.log('🗑️ Deleting from Local Disk');
         await localStorageService.deleteFile(file.localPath);
-        console.log('✅ File deleted from Local Disk');
       } catch (localError) {
         logger.logError(localError, req, {
           controller: 'fileController',
@@ -461,9 +500,7 @@ exports.deleteFile = async (req, res) => {
     // Delete from Google Drive using OAuth (user's Drive)
     if (file.storageMethod === 'google_drive' && file.googleDriveFileId) {
       try {
-        console.log('🗑️ Deleting from Google Drive (OAuth)');
         await googleDriveService.deleteFile(file.googleDriveFileId, user._id.toString());
-        console.log('✅ File deleted from Google Drive (OAuth)');
       } catch (driveError) {
         logger.logError(driveError, req, {
           controller: 'fileController',
@@ -502,3 +539,108 @@ exports.deleteFile = async (req, res) => {
   }
 };
 
+/**
+ * ========================================
+ * FILE EDIT (local_disk only)
+ * ========================================
+ */
+
+/** Text-editable extensions */
+const EDITABLE_EXTENSIONS = new Set([
+  'html', 'htm', 'md', 'txt',
+  'js', 'jsx', 'ts', 'tsx',
+  'css', 'scss', 'less',
+  'json', 'xml', 'yaml', 'yml', 'csv',
+  'java', 'py', 'rb', 'php', 'sh', 'c', 'cpp', 'go', 'rs', 'swift',
+]);
+
+/**
+ * Update file content (text-based local_disk files only)
+ * PUT /api/v1/files/:fileId/content
+ */
+exports.updateFileContent = async (req, res) => {
+  try {
+    const { fileId } = req.params;
+    const { content } = req.body;
+    const user = req.user;
+
+    if (!fileId || !user) {
+      return res.status(400).json({ success: false, message: 'Invalid request' });
+    }
+
+    if (typeof content !== 'string') {
+      return res.status(400).json({ success: false, message: 'Content must be a string' });
+    }
+
+    const file = await FileModel.findOne({
+      _id: fileId,
+      owner: user._id,
+      isDeleted: false,
+    });
+
+    if (!file) {
+      return res.status(404).json({ success: false, message: 'File not found' });
+    }
+
+    if (file.storageMethod !== 'local_disk') {
+      return res.status(400).json({
+        success: false,
+        message: 'Only locally-stored files can be edited. Google Drive files must be edited in Drive.',
+      });
+    }
+
+    const ext = (file.name.split('.').pop() || '').toLowerCase();
+    if (!EDITABLE_EXTENSIONS.has(ext)) {
+      return res.status(400).json({
+        success: false,
+        message: `Files of type '.${ext}' cannot be edited in the browser.`,
+      });
+    }
+
+    if (!file.localPath) {
+      return res.status(404).json({ success: false, message: 'Local file path is missing' });
+    }
+
+    // --- Path Traversal Guard ---
+    const uploadsRoot = path.resolve(localStorageService.getUploadPath());
+    const resolvedPath = path.resolve(file.localPath);
+    if (!resolvedPath.startsWith(uploadsRoot + path.sep) && resolvedPath !== uploadsRoot) {
+      logger.logError(new Error('Path traversal attempt blocked on edit'), req, {
+        controller: 'fileController',
+        function: 'updateFileContent',
+        resourceType: 'file',
+        resourceId: fileId,
+        level: 'critical',
+        context: { userId: req?.user?._id, storedPath: file.localPath },
+      });
+      return res.status(403).json({ success: false, message: 'Access denied' });
+    }
+
+    if (!fs.existsSync(resolvedPath)) {
+      return res.status(404).json({ success: false, message: 'Local file not found on disk' });
+    }
+
+    await fs.promises.writeFile(resolvedPath, content, 'utf8');
+
+    const newSize = Buffer.byteLength(content, 'utf8');
+    await FileModel.updateOne({ _id: fileId }, { $set: { size: newSize } });
+
+    return res.status(200).json({
+      success: true,
+      message: 'File updated successfully',
+      data: { fileId, size: newSize },
+    });
+  } catch (err) {
+    logger.logError(err, req, {
+      controller: 'fileController',
+      function: 'updateFileContent',
+      resourceType: 'file',
+      resourceId: req.params?.fileId,
+      context: { userId: req?.user?._id },
+    });
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error: ' + err.message,
+    });
+  }
+};

--- a/backend/controllers/v1/fileController.js
+++ b/backend/controllers/v1/fileController.js
@@ -1,7 +1,9 @@
 const FileModel = require("../../models/fileModels");
 const UserModel = require("../../models/userModels");
 const googleDriveService = require("../../services/googleDriveService");
+const localStorageService = require("../../services/localStorageService");
 const logger = require("../../utils/loggerUtility");
+const fs = require('fs');
 
 /**
  * ========================================
@@ -75,11 +77,13 @@ exports.validateFile = async (req, res, next) => {
       });
     }
 
-    // Check if Google Drive is connected (required for OAuth uploads)
-    if (!user.googleDriveConnected) {
+    // Check if either Google Drive is connected OR local upload is enabled
+    const localFileUploadEnabled = user.localFileUploadEnabled !== undefined ? user.localFileUploadEnabled : false;
+    
+    if (!user.googleDriveConnected && !localFileUploadEnabled) {
       return res.status(403).json({
         success: false,
-        message: "Google Drive is not connected. Please connect your Google Drive account from your profile settings.",
+        message: "No storage method is configured. Please connect Google Drive or enable local upload in your profile settings.",
       });
     }
 
@@ -156,8 +160,67 @@ exports.uploadFile = async (req, res) => {
       });
     }
 
-    // Upload to Google Drive using OAuth (user's Drive)
+    // 1. Try Local Storage if enabled for user
+    const localFileUploadEnabled = user.localFileUploadEnabled !== undefined ? user.localFileUploadEnabled : false;
+    
+    if (localFileUploadEnabled) {
+      try {
+        console.log('📤 Uploading to Local Disk');
+        const result = await localStorageService.uploadFile(req.file.buffer, req.file.originalname);
+        
+        console.log(`✅ File stored on Local Disk: ${result.fileName}`);
+
+        const newFile = new FileModel({
+          owner: user._id,
+          name: req.file.originalname,
+          storageMethod: 'local_disk',
+          localPath: result.filePath,
+          url: result.url, // Relative URL for public access
+          downloadUrl: `/api/v1/files/${result.fileName}`, // Placeholder or actual download route
+          type: req.file.mimetype,
+          size: result.size || req.file.size,
+          uploadedAt: new Date(),
+        });
+
+        const savedFile = await newFile.save();
+        
+        // Update download URL with the real ID
+        savedFile.downloadUrl = `/api/v1/files/${savedFile._id}`;
+        await savedFile.save();
+
+        return res.status(200).json({
+          success: true,
+          message: "File uploaded successfully to local storage",
+          data: savedFile,
+        });
+      } catch (localError) {
+        logger.logError(localError, req, {
+          controller: 'fileController',
+          function: 'uploadFile',
+          resourceType: 'file',
+          level: 'error',
+          context: { userId: req?.user?._id, fileName: req.file?.originalname, storage: 'local' }
+        });
+        // Fallback to Google Drive if local fails and Drive is connected
+        if (!user.googleDriveConnected) {
+          return res.status(500).json({
+            success: false,
+            message: "Failed to upload to local storage: " + localError.message,
+          });
+        }
+        console.log('⚠️ Local upload failed, falling back to Google Drive');
+      }
+    }
+
+    // 2. Upload to Google Drive using OAuth (user's Drive)
     try {
+      if (!user.googleDriveConnected) {
+        return res.status(403).json({
+          success: false,
+          message: "Google Drive is not connected and local upload is disabled.",
+        });
+      }
+
       console.log('📤 Uploading to Google Drive (OAuth)');
       
       // Get user's folder name (default: "CodeShare-Uploads")
@@ -190,7 +253,7 @@ exports.uploadFile = async (req, res) => {
 
       res.status(200).json({
         success: true,
-        message: "File uploaded successfully",
+        message: "File uploaded successfully to Google Drive",
         data: savedFile,
       });
     } catch (driveError) {
@@ -251,8 +314,48 @@ exports.downloadFile = async (req, res) => {
       });
     }
 
+    // Check storage method
+    if (file.storageMethod === 'local_disk') {
+      try {
+        console.log('📥 Downloading from Local Disk');
+        
+        if (!file.localPath || !fs.existsSync(file.localPath)) {
+          return res.status(404).json({
+            success: false,
+            message: "Local file not found on disk",
+          });
+        }
+
+        // Set response headers
+        const isPreview = req.query.preview === 'true';
+        const disposition = isPreview ? 'inline' : 'attachment';
+        
+        res.setHeader('Content-Type', file.type || 'application/octet-stream');
+        res.setHeader('Content-Disposition', `${disposition}; filename="${file.name}"`);
+        
+        // Stream file to client
+        const fileStream = fs.createReadStream(file.localPath);
+        fileStream.pipe(res);
+        
+        console.log('✅ File streamed from Local Disk');
+        return;
+      } catch (localError) {
+        logger.logError(localError, req, {
+          controller: 'fileController',
+          function: 'downloadFile',
+          resourceType: 'file',
+          resourceId: fileId,
+          context: { userId: req?.user?._id, storage: 'local' }
+        });
+        return res.status(500).json({
+          success: false,
+          message: "Failed to download from local storage: " + localError.message,
+        });
+      }
+    }
+
     // Check if file has Google Drive ID
-    if (!file.googleDriveFileId) {
+    if (!file.googleDriveFileId && file.storageMethod === 'google_drive') {
       return res.status(400).json({
         success: false,
         message: "File is not stored in Google Drive",
@@ -265,9 +368,12 @@ exports.downloadFile = async (req, res) => {
       
       const stream = await googleDriveService.downloadFile(file.googleDriveFileId, user._id.toString());
       
+      const isPreview = req.query.preview === 'true';
+      const disposition = isPreview ? 'inline' : 'attachment';
+
       // Set response headers
       res.setHeader('Content-Type', file.type || 'application/octet-stream');
-      res.setHeader('Content-Disposition', `attachment; filename="${file.name}"`);
+      res.setHeader('Content-Disposition', `${disposition}; filename="${file.name}"`);
       res.setHeader('Cache-Control', 'private, max-age=3600');
 
       // Stream file to client
@@ -334,8 +440,26 @@ exports.deleteFile = async (req, res) => {
       });
     }
 
+    // Delete from Local Disk
+    if (file.storageMethod === 'local_disk' && file.localPath) {
+      try {
+        console.log('🗑️ Deleting from Local Disk');
+        await localStorageService.deleteFile(file.localPath);
+        console.log('✅ File deleted from Local Disk');
+      } catch (localError) {
+        logger.logError(localError, req, {
+          controller: 'fileController',
+          function: 'deleteFile',
+          resourceType: 'file',
+          resourceId: fileId,
+          level: 'warning',
+          context: { userId: req?.user?._id, storage: 'local' }
+        });
+      }
+    }
+
     // Delete from Google Drive using OAuth (user's Drive)
-    if (file.googleDriveFileId) {
+    if (file.storageMethod === 'google_drive' && file.googleDriveFileId) {
       try {
         console.log('🗑️ Deleting from Google Drive (OAuth)');
         await googleDriveService.deleteFile(file.googleDriveFileId, user._id.toString());

--- a/backend/middleware/Authmiddleware.js
+++ b/backend/middleware/Authmiddleware.js
@@ -14,7 +14,7 @@ module.exports = () => {
                     token = req.headers.authorization;
                 }
             }
-            if (!req.cookies.token && req.body && req.body.isPublic) {
+            if (!token && req.body && req.body.isPublic) {
                 const data = {
                     _id: '',
                     username: 'username',

--- a/backend/middleware/Authmiddleware.js
+++ b/backend/middleware/Authmiddleware.js
@@ -4,7 +4,16 @@ const userModel = require('../models/userModels');
 module.exports = () => {
     return async (req, res, next) => {
         try {
-            const token = req.cookies.token;
+            let token = req.cookies.token;
+            
+            // Fallback to Authorization header
+            if (!token && req.headers.authorization) {
+                if (req.headers.authorization.startsWith('Bearer ')) {
+                    token = req.headers.authorization.split(' ')[1];
+                } else {
+                    token = req.headers.authorization;
+                }
+            }
             if (!req.cookies.token && req.body && req.body.isPublic) {
                 const data = {
                     _id: '',

--- a/backend/models/fileModels.js
+++ b/backend/models/fileModels.js
@@ -19,10 +19,10 @@ const fileSchema = new mongoose.Schema({
         required: true,
         index: true, // Index for search by name
     },
-    // Storage method: 'google_drive' (primary), 'mongodb' (for future)
+    // Storage method: 'google_drive' (primary), 'mongodb' (for future), 'local_disk'
     storageMethod: {
         type: String,
-        enum: ['google_drive', 'mongodb'],
+        enum: ['google_drive', 'mongodb', 'local_disk'],
         default: 'google_drive',
         required: true,
     },
@@ -39,6 +39,11 @@ const fileSchema = new mongoose.Schema({
     url: {
         type: String, // View link
         required: false,
+    },
+    // Local storage fields
+    localPath: {
+        type: String,
+        required: function() { return this.storageMethod === 'local_disk'; },
     },
     // MongoDB GridFS fields (for future)
     gridfsId: {

--- a/backend/models/userModels.js
+++ b/backend/models/userModels.js
@@ -96,6 +96,10 @@ const userSchema = new mongoose.Schema(
             type: String,
             default: "CodeShare-Uploads",
         },
+        localFileUploadEnabled: {
+            type: Boolean,
+            default: false,
+        },
     },
     { timestamps: true }
 );

--- a/backend/routes/v1/files.route.js
+++ b/backend/routes/v1/files.route.js
@@ -8,6 +8,7 @@ const {
     deleteFile, 
     getFiles,
     validateFile,
+    updateFileContent,
 } = require("../../controllers/v1/fileController");
 const multer = require("multer");
 
@@ -25,7 +26,8 @@ router.use(authenticateUser());
 // File management (independent from documents)
 router.get("/", activityLogger('file_get', 'file'), getFiles); // Get all files for user
 router.post("/", validateFile, memoryStorage.single("file"), activityLogger('file_upload', 'file'), uploadFile); // Upload file (no document required)
-router.get("/:fileId", activityLogger('file_download', 'file'), downloadFile); // Download file
+router.get("/:fileId", activityLogger('file_download', 'file'), downloadFile); // Download / stream file
+router.put("/:fileId/content", activityLogger('file_edit', 'file'), updateFileContent); // Update file content (local_disk text files)
 router.delete("/:fileId", activityLogger('file_delete', 'file'), deleteFile); // Delete file
 
 module.exports = router;

--- a/backend/services/localStorageService.js
+++ b/backend/services/localStorageService.js
@@ -1,39 +1,51 @@
 const fs = require('fs');
 const path = require('path');
+const logger = require('../utils/loggerUtility');
 
 class LocalStorageService {
     constructor() {
-        this.primaryPath = '/home/ubuntu/Auction/backend/public/uploads/codeshare';
+        // Prefer an environment variable so path is not hardcoded per machine.
+        // Falls back to the legacy absolute path for backward compatibility.
+        this.primaryPath = process.env.LOCAL_UPLOAD_PATH || '/home/ubuntu/Auction/backend/public/uploads/codeshare';
         this.fallbackPath = path.join(__dirname, '../public/uploads/codeshare');
+        this._resolvedUploadPath = null; // Lazy, cached after first resolution
     }
 
     /**
-     * Get the appropriate upload path based on availability
-     * @returns {string} The path to use for uploads
+     * Get the appropriate upload path based on availability.
+     * Resolves once and caches the result. Does NOT throw at module-load time.
+     * @returns {string} The absolute path to use for uploads
      */
     getUploadPath() {
+        if (this._resolvedUploadPath) {
+            return this._resolvedUploadPath;
+        }
+
+        // Try primary path
         try {
-            // Check if we are on a system where the primary path is viable
-            // We check the base path '/home/ubuntu' to avoid creating deep directories on incompatible systems
-            if (fs.existsSync('/home/ubuntu')) {
+            const primaryBase = path.dirname(this.primaryPath).split(path.sep)[1]; // e.g. 'home'
+            if (fs.existsSync('/' + primaryBase)) {
                 if (!fs.existsSync(this.primaryPath)) {
                     fs.mkdirSync(this.primaryPath, { recursive: true });
                 }
-                return this.primaryPath;
+                this._resolvedUploadPath = this.primaryPath;
+                return this._resolvedUploadPath;
             }
         } catch (err) {
-            console.error('LocalStorageService: Error checking primary path:', err);
+            console.error('LocalStorageService: Error checking primary path:', err.message);
         }
 
-        // Fallback to project relative path
+        // Fall back to project-relative path
         try {
             if (!fs.existsSync(this.fallbackPath)) {
                 fs.mkdirSync(this.fallbackPath, { recursive: true });
             }
-            return this.fallbackPath;
+            this._resolvedUploadPath = this.fallbackPath;
+            return this._resolvedUploadPath;
         } catch (err) {
-            console.error('LocalStorageService: Error creating fallback path:', err);
-            throw new Error('Failed to initialize local storage path');
+            // Do not crash the process — defer error to upload time
+            console.error('LocalStorageService: Error creating fallback path:', err.message);
+            throw new Error('Failed to initialize local storage path: ' + err.message);
         }
     }
 
@@ -49,10 +61,9 @@ class LocalStorageService {
             const uniqueName = `${Date.now()}_${fileName.replace(/\s+/g, '-')}`;
             const filePath = path.join(uploadDir, uniqueName);
 
-            fs.writeFileSync(filePath, fileBuffer);
+            // Async write — does not block the event loop
+            await fs.promises.writeFile(filePath, fileBuffer);
 
-            // Calculate relative URL for preview/access
-            // The 'public' directory is served at root
             const url = `/uploads/codeshare/${uniqueName}`;
 
             return {
@@ -62,7 +73,7 @@ class LocalStorageService {
                 size: fileBuffer.length
             };
         } catch (error) {
-            console.error('LocalStorageService: Upload error:', error);
+            console.error('LocalStorageService: Upload error:', error.message);
             throw error;
         }
     }
@@ -75,12 +86,12 @@ class LocalStorageService {
     async deleteFile(filePath) {
         try {
             if (fs.existsSync(filePath)) {
-                fs.unlinkSync(filePath);
+                await fs.promises.unlink(filePath);
                 return true;
             }
             return false;
         } catch (error) {
-            console.error('LocalStorageService: Delete error:', error);
+            console.error('LocalStorageService: Delete error:', error.message);
             return false;
         }
     }

--- a/backend/services/localStorageService.js
+++ b/backend/services/localStorageService.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+
+class LocalStorageService {
+    constructor() {
+        this.primaryPath = '/home/ubuntu/Auction/backend/public/uploads/codeshare';
+        this.fallbackPath = path.join(__dirname, '../public/uploads/codeshare');
+    }
+
+    /**
+     * Get the appropriate upload path based on availability
+     * @returns {string} The path to use for uploads
+     */
+    getUploadPath() {
+        try {
+            // Check if we are on a system where the primary path is viable
+            // We check the base path '/home/ubuntu' to avoid creating deep directories on incompatible systems
+            if (fs.existsSync('/home/ubuntu')) {
+                if (!fs.existsSync(this.primaryPath)) {
+                    fs.mkdirSync(this.primaryPath, { recursive: true });
+                }
+                return this.primaryPath;
+            }
+        } catch (err) {
+            console.error('LocalStorageService: Error checking primary path:', err);
+        }
+
+        // Fallback to project relative path
+        try {
+            if (!fs.existsSync(this.fallbackPath)) {
+                fs.mkdirSync(this.fallbackPath, { recursive: true });
+            }
+            return this.fallbackPath;
+        } catch (err) {
+            console.error('LocalStorageService: Error creating fallback path:', err);
+            throw new Error('Failed to initialize local storage path');
+        }
+    }
+
+    /**
+     * Upload a file to local disk
+     * @param {Buffer} fileBuffer - File content
+     * @param {string} fileName - Original file name
+     * @returns {Promise<Object>} File metadata
+     */
+    async uploadFile(fileBuffer, fileName) {
+        try {
+            const uploadDir = this.getUploadPath();
+            const uniqueName = `${Date.now()}_${fileName.replace(/\s+/g, '-')}`;
+            const filePath = path.join(uploadDir, uniqueName);
+
+            fs.writeFileSync(filePath, fileBuffer);
+
+            // Calculate relative URL for preview/access
+            // The 'public' directory is served at root
+            const url = `/uploads/codeshare/${uniqueName}`;
+
+            return {
+                fileName: uniqueName,
+                filePath: filePath,
+                url: url,
+                size: fileBuffer.length
+            };
+        } catch (error) {
+            console.error('LocalStorageService: Upload error:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Delete a file from local disk
+     * @param {string} filePath - Absolute path to the file
+     * @returns {Promise<boolean>} Success status
+     */
+    async deleteFile(filePath) {
+        try {
+            if (fs.existsSync(filePath)) {
+                fs.unlinkSync(filePath);
+                return true;
+            }
+            return false;
+        } catch (error) {
+            console.error('LocalStorageService: Delete error:', error);
+            return false;
+        }
+    }
+}
+
+module.exports = new LocalStorageService();

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,7 +4,7 @@ const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 const path = require('path');
 const compression = require('compression');
-const localStorageService = require('../services/localStorageService');
+
 require("dotenv").config();
 var bodyParser = require("body-parser");
 
@@ -49,8 +49,8 @@ app.use(express.json({ limit: '2mb' }));
 // Serve static files from public directory
 app.use(express.static(path.join(__dirname, '../public')));
 
-// Serve uploaded files from the actual storage path (for local storage preview)
-app.use('/uploads/codeshare', express.static(localStorageService.getUploadPath()));
+// NOTE: Local uploads are intentionally NOT served via static route.
+// All file access is authenticated and routed through /api/v1/files/:id
 
 app.set('view engine', 'ejs');
 app.set('views', './views');

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 const path = require('path');
 const compression = require('compression');
+const localStorageService = require('../services/localStorageService');
 require("dotenv").config();
 var bodyParser = require("body-parser");
 
@@ -47,6 +48,9 @@ app.use(express.json({ limit: '2mb' }));
 
 // Serve static files from public directory
 app.use(express.static(path.join(__dirname, '../public')));
+
+// Serve uploaded files from the actual storage path (for local storage preview)
+app.use('/uploads/codeshare', express.static(localStorageService.getUploadPath()));
 
 app.set('view engine', 'ejs');
 app.set('views', './views');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,14 +24,17 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "remark-gfm": "^4.0.1",
         "socket.io-client": "^4.7.5",
         "tinymce": "^7.4.1",
         "web-vitals": "^2.1.4",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.3.6"
@@ -3963,6 +3966,31 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
@@ -4159,6 +4187,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.7",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
@@ -4181,6 +4217,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -4210,6 +4254,14 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -4299,10 +4351,23 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
       "version": "20.12.5",
@@ -4443,6 +4508,11 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -5623,6 +5693,15 @@
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5965,6 +6044,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/cfb": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
@@ -5998,6 +6086,42 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-types": {
@@ -6234,6 +6358,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -6951,6 +7084,18 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -7125,6 +7270,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8239,6 +8396,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
@@ -8371,6 +8537,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9207,6 +9378,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -9315,6 +9524,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -9604,6 +9822,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -9623,6 +9846,28 @@
       "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -9761,6 +10006,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -9833,6 +10087,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-map": {
@@ -12409,6 +12672,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12482,6 +12754,281 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -12531,6 +13078,541 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -13161,6 +14243,29 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -14728,6 +15833,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -15002,6 +16116,32 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -15288,6 +16428,68 @@
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/renderkid": {
@@ -16059,6 +17261,15 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -16387,6 +17598,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -16482,6 +17706,22 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylehacks": {
@@ -17057,6 +18297,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -17300,6 +18558,35 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -17309,6 +18596,69 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -17459,6 +18809,32 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -18463,6 +19839,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "remark-gfm": "^4.0.1",
     "socket.io-client": "^4.7.5",
     "tinymce": "^7.4.1",
     "web-vitals": "^2.1.4",
@@ -51,6 +53,7 @@
     ]
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6"

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,6 +1,6 @@
 {
-    "backend_url": "https://codeshare.auctionng.org",
-    "backend_socket_url": "https://codeshare.auctionng.org",
+    "backend_url": "http://localhost:8080",
+    "backend_socket_url": "http://localhost:8080",
     "auction_url": "https://auctionng.org",
     "adsense_publisher_id": "ca-pub-8653039795540767"
 }

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -962,7 +962,7 @@ export default function MainPage(props) {
             />
           )}
 
-          {/* Page title and version - LOGGED USERS ONLY */}
+          {/* Page title and version - LOGGED USERS */}
           {currUser && (
             <div className="flex flex-row gap-3 items-center justify-between px-4 py-3 border-b border-gray-200 flex-shrink-0">
               <div className="flex items-center gap-3 flex-1">
@@ -1037,6 +1037,62 @@ export default function MainPage(props) {
                 <span>💾</span>
                 <span className="hidden sm:inline">Save</span>
               </button>
+            </div>
+          )}
+
+          {/* Version history bar - PUBLIC users (read-only, no Save button) */}
+          {!currUser && latestVersion.timeformate && (
+            <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50 flex-shrink-0">
+              <div className="relative inline-block" ref={versionHistoryRef}>
+                <button
+                  onClick={() => {
+                    getAllversionData(true);
+                    setDropdownVisibility(() => {
+                      var val = structuredClone(dropdownVisibility);
+                      val.history = !val.history;
+                      val.file = false;
+                      val.profile = false;
+                      return val;
+                    });
+                  }}
+                  type="button"
+                  className="gap-2 flex items-center bg-white border border-gray-200 hover:bg-gray-50 px-3 py-1.5 transition rounded-lg text-sm font-medium text-gray-700 shadow-sm"
+                  title="View previous versions of this document"
+                >
+                  <span>🕐</span>
+                  <span>Version history</span>
+                  <span className="text-gray-400">{downArrowIcon}</span>
+                </button>
+
+                {dropdownVisibility.history && allVersionData.length > 0 && (
+                  <div
+                    className="absolute left-0 z-10 mt-2 min-w-[240px] max-w-[300px] max-h-96 overflow-auto p-1 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+                    role="menu"
+                  >
+                    <ul className="py-2 text-sm text-gray-700">
+                      {allVersionData.map((v, index) => (
+                        <li
+                          key={index}
+                          className="flex px-1 items-center min-w-[250px]"
+                        >
+                          <div className="min-w-[20px] max-w-[30px]" title="Current version">
+                            {v.isCurrent && currentVersionIcon(v)}
+                            {v.isLoaded && !v.isCurrent && versionIndicatorIcon}
+                          </div>
+                          <div
+                            title="Click to load this version"
+                            onClick={() => loadSpecificVersion(v.time, index)}
+                            className="flex-1 version-text cursor-pointer px-2 py-1 hover:bg-gray-100 rounded"
+                          >
+                            Version - {v.timeformat}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+              <span className="text-xs text-gray-400 hidden sm:inline">Read-only · {userSlug}</span>
             </div>
           )}
 

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -37,6 +37,7 @@ import FloatingHint from "./components/editor/FloatingHint";
 import FeatureModal from "./components/editor/FeatureModal";
 import RedirectUrlInput from "./components/editor/RedirectUrlInput";
 import InputModal from "../components/modals/InputModal";
+import FilePreviewModal from "./components/editor/FilePreviewModal";
 
 export default function MainPage(props) {
   const { currUser, setCurrUser } = useContext(UserContext);
@@ -83,6 +84,7 @@ export default function MainPage(props) {
   const [showRenameModal, setShowRenameModal] = useState(false);
   const [renamePageId, setRenamePageId] = useState(null);
   const [saveModalType, setSaveModalType] = useState(null); // 'public' or 'new'
+  const [previewFile, setPreviewFile] = useState(null);
 
   // Note: Auth checking and userId validation now handled by PrivateRoute component
   
@@ -912,6 +914,7 @@ export default function MainPage(props) {
             onPagePinToggle={handlePagePinToggle}
             onSelectFile={onSelectFile}
             onFileRemove={confirmFileRemove}
+            onFilePreview={(file) => setPreviewFile(file)}
             privateFileList={privateFileList}
             // Public user URL input props
             tmpSlug={tmpSlug}
@@ -937,6 +940,7 @@ export default function MainPage(props) {
             onPagePinToggle={handlePagePinToggle}
             onSelectFile={onSelectFile}
             onFileRemove={confirmFileRemove}
+            onFilePreview={(file) => setPreviewFile(file)}
             privateFileList={privateFileList}
           />
         )}
@@ -1138,6 +1142,14 @@ export default function MainPage(props) {
         submitButtonText="Rename"
         validateInput={validateRenameInput}
       />
+
+      {/* File Preview Modal */}
+      {previewFile && (
+        <FilePreviewModal 
+          file={previewFile} 
+          onClose={() => setPreviewFile(null)} 
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -38,6 +38,7 @@ import FeatureModal from "./components/editor/FeatureModal";
 import RedirectUrlInput from "./components/editor/RedirectUrlInput";
 import InputModal from "../components/modals/InputModal";
 import FilePreviewModal from "./components/editor/FilePreviewModal";
+import FileEditModal from "./components/editor/FileEditModal";
 
 export default function MainPage(props) {
   const { currUser, setCurrUser } = useContext(UserContext);
@@ -85,6 +86,7 @@ export default function MainPage(props) {
   const [renamePageId, setRenamePageId] = useState(null);
   const [saveModalType, setSaveModalType] = useState(null); // 'public' or 'new'
   const [previewFile, setPreviewFile] = useState(null);
+  const [editFile, setEditFile] = useState(null);
 
   // Note: Auth checking and userId validation now handled by PrivateRoute component
   
@@ -913,8 +915,9 @@ export default function MainPage(props) {
             onPageReorder={handlePageReorder}
             onPagePinToggle={handlePagePinToggle}
             onSelectFile={onSelectFile}
-            onFileRemove={confirmFileRemove}
+             onFileRemove={confirmFileRemove}
             onFilePreview={(file) => setPreviewFile(file)}
+            onFileEdit={(file) => setEditFile(file)}
             privateFileList={privateFileList}
             // Public user URL input props
             tmpSlug={tmpSlug}
@@ -941,6 +944,7 @@ export default function MainPage(props) {
             onSelectFile={onSelectFile}
             onFileRemove={confirmFileRemove}
             onFilePreview={(file) => setPreviewFile(file)}
+            onFileEdit={(file) => setEditFile(file)}
             privateFileList={privateFileList}
           />
         )}
@@ -1148,6 +1152,20 @@ export default function MainPage(props) {
         <FilePreviewModal 
           file={previewFile} 
           onClose={() => setPreviewFile(null)} 
+        />
+      )}
+
+      {/* File Edit Modal */}
+      {editFile && (
+        <FileEditModal
+          file={editFile}
+          onClose={() => setEditFile(null)}
+          onSaved={(updatedFile) => {
+            // Refresh size in the file list so UI stays in sync
+            setPrivateFileList((prev) =>
+              prev.map((f) => f._id === updatedFile._id ? { ...f, size: updatedFile.size } : f)
+            );
+          }}
         />
       )}
     </div>

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -962,139 +962,84 @@ export default function MainPage(props) {
             />
           )}
 
-          {/* Page title and version - LOGGED USERS */}
-          {currUser && (
-            <div className="flex flex-row gap-3 items-center justify-between px-4 py-3 border-b border-gray-200 flex-shrink-0">
-              <div className="flex items-center gap-3 flex-1">
-                <div className="relative inline-block" ref={versionHistoryRef}>
-                  <button
-                    onClick={() => {
-                      getAllversionData(true);
-                      setDropdownVisibility(() => {
-                        var val = structuredClone(dropdownVisibility);
-                        val.history = !val.history;
-                        val.file = false;
-                        val.profile = false;
-                        return val;
-                      });
-                    }}
-                    type="button"
-                    className="gap-3 flex items-center bg-gray-100 hover:bg-gray-200 px-4 py-2 transition rounded-lg text-sm font-medium text-gray-900"
-                  >
-                    <span className="capitalize">📄 {latestVersion.timeformate ? userSlug : "New page"}</span>
-                    <span className="text-gray-500" title="Click to show page versions">
-                      {downArrowIcon}
-                    </span>
-                  </button>
+          {/* Toolbar: page title (left) + version picker + Save (right) */}
+          {(currUser || latestVersion.timeformate) && (
+            <div className="flex flex-row items-center justify-between gap-3 px-4 py-2.5 border-b border-gray-200 bg-white flex-shrink-0">
+              {/* Left: page label */}
+              <span className="text-sm font-medium text-gray-600 capitalize truncate max-w-[40%]">
+                📄 {latestVersion.timeformate ? userSlug : "New page"}
+              </span>
+
+              {/* Right: version picker + Save */}
+              <div className="flex items-center gap-2 flex-shrink-0">
+
+                {/* Version picker (shown when document has at least one saved version) */}
+                {latestVersion.timeformate && (
+                  <div className="relative" ref={versionHistoryRef}>
+                    <button
+                      onClick={() => {
+                        getAllversionData(true);
+                        setDropdownVisibility(() => {
+                          var val = structuredClone(dropdownVisibility);
+                          val.history = !val.history;
+                          val.file = false;
+                          val.profile = false;
+                          return val;
+                        });
+                      }}
+                      type="button"
+                      className="gap-2 flex items-center bg-gray-100 hover:bg-gray-200 px-3 py-1.5 transition rounded-lg text-sm font-medium text-gray-700"
+                      title="View version history"
+                    >
+                      <span>🕐</span>
+                      <span className="hidden sm:inline">History</span>
+                      <span className="text-gray-500">{downArrowIcon}</span>
+                    </button>
 
                     {dropdownVisibility.history && allVersionData.length > 0 && (
                       <div
-                        className="absolute left-0 z-10 mt-2 min-w-[240px] max-w-[300px] max-h-96 overflow-auto p-1 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                        className="absolute right-0 z-10 mt-2 w-max max-h-96 overflow-auto p-1 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
                         role="menu"
-                        aria-orientation="vertical"
-                        aria-labelledby="menu-button"
                       >
-                        <ul
-                          className="py-2 text-sm text-gray-700 dark:text-gray-200 "
-                          aria-labelledby="dropdownDefaultButton"
-                        >
-                          {allVersionData.map((v, index) => {
-                            return (
-                              <li
-                                key={index}
-                                className="flex px-1 items-center justify-end min-w-[250px] max-w-[380px]"
+                        <ul className="py-1 text-sm text-gray-700">
+                          {allVersionData.map((v, index) => (
+                            <li
+                              key={index}
+                              className="flex items-center px-1 whitespace-nowrap"
+                            >
+                              <div className="w-5 flex-shrink-0" title="Current / loaded version">
+                                {v.isCurrent && currentVersionIcon(v)}
+                                {v.isLoaded && !v.isCurrent && versionIndicatorIcon}
+                              </div>
+                              <div
+                                title="Click to load this version"
+                                onClick={() => loadSpecificVersion(v.time, index)}
+                                className="flex-1 cursor-pointer px-2 py-1.5 hover:bg-gray-100 rounded"
                               >
-                                <div
-                                  className="min-w-[20px] max-w-[30px]"
-                                  title="Current version"
-                                >
-                                  {v.isCurrent && currentVersionIcon(v)}
-                                  {v.isLoaded && !v.isCurrent && versionIndicatorIcon}
-                                </div>
-                                <div
-                                  title="Click to load this version"
-                                  onClick={() => {
-                                    loadSpecificVersion(v.time, index);
-                                  }}
-                                  className="min-w-[230px] max-w-[350px] version-text text-justify cursor-pointer block gap-1 px-2 py-1 border-1 border-black-100 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                                >
-                                  Version - {v.timeformat}
-                                </div>
-                              </li>
-                            );
-                          })}
+                                Version - {v.timeformat}
+                              </div>
+                            </li>
+                          ))}
                         </ul>
                       </div>
                     )}
                   </div>
-              </div>
-              
-              <button
-                type="button"
-                onClick={(e) => saveData()}
-                className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-lg transition shadow-sm flex items-center gap-2"
-              >
-                <span>💾</span>
-                <span className="hidden sm:inline">Save</span>
-              </button>
-            </div>
-          )}
-
-          {/* Version history bar - PUBLIC users (read-only, no Save button) */}
-          {!currUser && latestVersion.timeformate && (
-            <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50 flex-shrink-0">
-              <div className="relative inline-block" ref={versionHistoryRef}>
-                <button
-                  onClick={() => {
-                    getAllversionData(true);
-                    setDropdownVisibility(() => {
-                      var val = structuredClone(dropdownVisibility);
-                      val.history = !val.history;
-                      val.file = false;
-                      val.profile = false;
-                      return val;
-                    });
-                  }}
-                  type="button"
-                  className="gap-2 flex items-center bg-white border border-gray-200 hover:bg-gray-50 px-3 py-1.5 transition rounded-lg text-sm font-medium text-gray-700 shadow-sm"
-                  title="View previous versions of this document"
-                >
-                  <span>🕐</span>
-                  <span>Version history</span>
-                  <span className="text-gray-400">{downArrowIcon}</span>
-                </button>
-
-                {dropdownVisibility.history && allVersionData.length > 0 && (
-                  <div
-                    className="absolute left-0 z-10 mt-2 min-w-[240px] max-w-[300px] max-h-96 overflow-auto p-1 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
-                    role="menu"
-                  >
-                    <ul className="py-2 text-sm text-gray-700">
-                      {allVersionData.map((v, index) => (
-                        <li
-                          key={index}
-                          className="flex px-1 items-center min-w-[250px]"
-                        >
-                          <div className="min-w-[20px] max-w-[30px]" title="Current version">
-                            {v.isCurrent && currentVersionIcon(v)}
-                            {v.isLoaded && !v.isCurrent && versionIndicatorIcon}
-                          </div>
-                          <div
-                            title="Click to load this version"
-                            onClick={() => loadSpecificVersion(v.time, index)}
-                            className="flex-1 version-text cursor-pointer px-2 py-1 hover:bg-gray-100 rounded"
-                          >
-                            Version - {v.timeformat}
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
                 )}
+
+                {/* Save — all users */}
+                <button
+                  type="button"
+                  onClick={() => saveData()}
+                  className="px-5 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-lg transition shadow-sm flex items-center gap-2"
+                >
+                  <span>💾</span>
+                  <span className="hidden sm:inline">Save</span>
+                </button>
               </div>
-              <span className="text-xs text-gray-400 hidden sm:inline">Read-only · {userSlug}</span>
             </div>
           )}
+
+
 
           {/* Editor */}
           <div className="tinymce-parent flex-1 overflow-hidden">

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -232,13 +232,16 @@ export default function AdminUsers() {
                         </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-left">
-                        <div className="flex flex-col">
-                          <span className={`px-2 py-1 text-xs font-semibold rounded-full inline-block mb-1 ${(user.fileUploadEnabled !== undefined && user.fileUploadEnabled) ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
-                            {(user.fileUploadEnabled !== undefined && user.fileUploadEnabled) ? 'Enabled' : 'Disabled'}
+                        <div className="flex flex-col space-y-1">
+                          <span className={`px-2 py-0.5 text-[10px] font-semibold rounded-full inline-block w-fit ${(user.fileUploadEnabled) ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                            GDrive: {user.fileUploadEnabled ? 'ON' : 'OFF'}
                           </span>
-                          {user.fileUploadEnabled && user.fileSizeLimit && (
-                            <span className="text-xs text-gray-500">
-                              {(user.fileSizeLimit / (1024 * 1024)).toFixed(1)} MB max
+                          <span className={`px-2 py-0.5 text-[10px] font-semibold rounded-full inline-block w-fit ${(user.localFileUploadEnabled) ? 'bg-purple-100 text-purple-800' : 'bg-gray-100 text-gray-600'}`}>
+                            Local: {user.localFileUploadEnabled ? 'ON' : 'OFF'}
+                          </span>
+                          {(user.fileUploadEnabled || user.localFileUploadEnabled) && user.fileSizeLimit && (
+                            <span className="text-[10px] text-gray-500 ml-1">
+                              Max: {(user.fileSizeLimit / (1024 * 1024)).toFixed(1)} MB
                             </span>
                           )}
                         </div>
@@ -360,6 +363,7 @@ function EditUserModal({ user, onClose, onSave }) {
     isActive: user.isActive !== undefined ? user.isActive : true,
     isVerified: user.isVerified !== undefined ? user.isVerified : false,
     fileUploadEnabled: user.fileUploadEnabled !== undefined ? user.fileUploadEnabled : false,
+    localFileUploadEnabled: user.localFileUploadEnabled !== undefined ? user.localFileUploadEnabled : false,
     fileSizeLimit: user.fileSizeLimit ? (user.fileSizeLimit / (1024 * 1024)).toFixed(1) : '1.0', // Convert bytes to MB
   });
 
@@ -369,11 +373,11 @@ function EditUserModal({ user, onClose, onSave }) {
     // Convert fileSizeLimit from MB to bytes before saving
     const dataToSave = {
       ...formData,
-      fileSizeLimit: formData.fileUploadEnabled 
+      fileSizeLimit: (formData.fileUploadEnabled || formData.localFileUploadEnabled)
         ? Math.round(parseFloat(formData.fileSizeLimit) * 1024 * 1024) // Convert MB to bytes
         : undefined,
-      // If fileUploadEnabled is false, set fileSizeLimit to undefined/null
-      ...(formData.fileUploadEnabled ? {} : { fileSizeLimit: undefined }),
+      // If no file upload is enabled, set fileSizeLimit to undefined/null
+      ...((formData.fileUploadEnabled || formData.localFileUploadEnabled) ? {} : { fileSizeLimit: undefined }),
     };
     
     onSave(dataToSave);
@@ -441,17 +445,30 @@ function EditUserModal({ user, onClose, onSave }) {
           <div className="border-t pt-4 mt-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">File Upload Settings</h3>
             
-            <div className="mb-4">
-              <label className="flex items-center mb-2">
+            <div className="mb-2">
+              <label className="flex items-center mb-1">
                 <input
                   type="checkbox"
                   checked={formData.fileUploadEnabled}
                   onChange={(e) => setFormData({ ...formData, fileUploadEnabled: e.target.checked })}
                   className="mr-2"
                 />
-                <span className="text-sm text-gray-700">Enable File Upload</span>
+                <span className="text-sm text-gray-700">Enable Google Drive Upload</span>
               </label>
-              <p className="text-xs text-gray-500 ml-6">Allow user to upload files to Google Drive</p>
+              <p className="text-[10px] text-gray-500 ml-6">Use user's personal Google Drive</p>
+            </div>
+
+            <div className="mb-4">
+              <label className="flex items-center mb-1">
+                <input
+                  type="checkbox"
+                  checked={formData.localFileUploadEnabled}
+                  onChange={(e) => setFormData({ ...formData, localFileUploadEnabled: e.target.checked })}
+                  className="mr-2"
+                />
+                <span className="text-sm text-gray-700">Enable Local Disk Upload</span>
+              </label>
+              <p className="text-[10px] text-gray-500 ml-6">Store files on server disk (/uploads)</p>
             </div>
             
             <div>
@@ -471,7 +488,7 @@ function EditUserModal({ user, onClose, onSave }) {
                   }
                 }}
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg"
-                disabled={!formData.fileUploadEnabled}
+                disabled={!formData.fileUploadEnabled && !formData.localFileUploadEnabled}
               />
               <p className="text-xs text-gray-500 mt-1">
                 Maximum file size allowed (default: 1.0 MB)

--- a/frontend/src/pages/components/editor/EditorSidebar.jsx
+++ b/frontend/src/pages/components/editor/EditorSidebar.jsx
@@ -26,6 +26,7 @@ import {
 import { getPresizeFileName, generateRandomString } from '../../../common/functions';
 import useClickOutside from '../../../hooks/useClickOutside';
 import useConfig from '../../../hooks/useConfig';
+import { isEditable } from './FileEditModal';
 import toast from 'react-hot-toast';
 
 const isPreviewable = (fileName) => {
@@ -49,6 +50,7 @@ const EditorSidebar = ({
   onSelectFile,
   onFileRemove,
   onFilePreview,
+  onFileEdit,
   privateFileList,
   onPageRename,
   onPageReorder,
@@ -321,7 +323,7 @@ const EditorSidebar = ({
                             {file.name ? getPresizeFileName(file.name) : "file"}
                           </span>
                         </div>
-                        <div className="flex gap-2 pt-2 border-t border-gray-100">
+                        <div className="flex gap-2 pt-2 border-t border-gray-100 flex-wrap">
                           <a
                             href={getFullUrl(file.downloadUrl || (file._id ? `/api/v1/files/${file._id}` : file.url))}
                             target="_blank"
@@ -337,6 +339,14 @@ const EditorSidebar = ({
                               className="flex-1 px-3 py-1.5 text-xs bg-blue-50 text-blue-600 rounded-md hover:bg-blue-100 font-medium transition"
                             >
                               Preview
+                            </button>
+                          )}
+                          {file.storageMethod === 'local_disk' && isEditable(file.name) && (
+                            <button
+                              onClick={() => onFileEdit(file)}
+                              className="flex-1 px-3 py-1.5 text-xs bg-violet-50 text-violet-600 rounded-md hover:bg-violet-100 font-medium transition"
+                            >
+                              Edit
                             </button>
                           )}
                           <button

--- a/frontend/src/pages/components/editor/EditorSidebar.jsx
+++ b/frontend/src/pages/components/editor/EditorSidebar.jsx
@@ -25,6 +25,7 @@ import {
 } from '../../../assets/svgs'
 import { getPresizeFileName, generateRandomString } from '../../../common/functions';
 import useClickOutside from '../../../hooks/useClickOutside';
+import useConfig from '../../../hooks/useConfig';
 import toast from 'react-hot-toast';
 
 const isPreviewable = (fileName) => {
@@ -53,9 +54,22 @@ const EditorSidebar = ({
   onPageReorder,
   onPagePinToggle
 }) => {
+  const { config } = useConfig();
   const [documentSearch, setDocumentSearch] = useState('');
   const [fileSearch, setFileSearch] = useState('');
   const [optimisticPages, setOptimisticPages] = useState(null);
+
+  // Helper to construct absolute URL
+  const getFullUrl = (targetUrl) => {
+    if (!targetUrl) return '';
+    if (targetUrl.startsWith('http')) return targetUrl;
+    
+    const baseUrl = config?.backend_url || '';
+    const cleanBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const cleanPath = targetUrl.startsWith('/') ? targetUrl : `/${targetUrl}`;
+    
+    return `${cleanBase}${cleanPath}`;
+  };
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -309,7 +323,7 @@ const EditorSidebar = ({
                         </div>
                         <div className="flex gap-2 pt-2 border-t border-gray-100">
                           <a
-                            href={file.url}
+                            href={getFullUrl(file.downloadUrl || (file._id ? `/api/v1/files/${file._id}` : file.url))}
                             target="_blank"
                             download={file.name}
                             rel="noreferrer"

--- a/frontend/src/pages/components/editor/EditorSidebar.jsx
+++ b/frontend/src/pages/components/editor/EditorSidebar.jsx
@@ -22,10 +22,16 @@ import {
   pinnedIcon,
   editIcon,
   fileIcon
-} from '../../../assets/svgs';
+} from '../../../assets/svgs'
 import { getPresizeFileName, generateRandomString } from '../../../common/functions';
 import useClickOutside from '../../../hooks/useClickOutside';
 import toast from 'react-hot-toast';
+
+const isPreviewable = (fileName) => {
+  if (!fileName) return false;
+  const ext = fileName.split('.').pop().toLowerCase();
+  return ['jpg', 'jpeg', 'png', 'gif', 'svg', 'pdf', 'html', 'md', 'txt', 'js', 'css', 'json'].includes(ext);
+};
 
 /**
  * EditorSidebar - Pages/Files sidebar for logged users
@@ -41,6 +47,7 @@ const EditorSidebar = ({
   onPageRemove,
   onSelectFile,
   onFileRemove,
+  onFilePreview,
   privateFileList,
   onPageRename,
   onPageReorder,
@@ -310,6 +317,14 @@ const EditorSidebar = ({
                           >
                             Download
                           </a>
+                          {isPreviewable(file.name) && (
+                            <button
+                              onClick={() => onFilePreview(file)}
+                              className="flex-1 px-3 py-1.5 text-xs bg-blue-50 text-blue-600 rounded-md hover:bg-blue-100 font-medium transition"
+                            >
+                              Preview
+                            </button>
+                          )}
                           <button
                             onClick={() => onFileRemove(file)}
                             className="px-3 py-1.5 text-xs bg-red-50 text-red-600 rounded-md hover:bg-red-100 font-medium transition"

--- a/frontend/src/pages/components/editor/FileEditModal.jsx
+++ b/frontend/src/pages/components/editor/FileEditModal.jsx
@@ -1,0 +1,241 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import useConfig from '../../../hooks/useConfig';
+import fileApi from '../../../services/api/fileApi';
+import toast from 'react-hot-toast';
+
+/**
+ * Extensions that can be edited in the browser.
+ * Must stay in sync with EDITABLE_EXTENSIONS on the backend.
+ */
+export const EDITABLE_EXTENSIONS = new Set([
+  'html', 'htm', 'md', 'txt',
+  'js', 'jsx', 'ts', 'tsx',
+  'css', 'scss', 'less',
+  'json', 'xml', 'yaml', 'yml', 'csv',
+  'java', 'py', 'rb', 'php', 'sh', 'c', 'cpp', 'go', 'rs', 'swift',
+]);
+
+export const isEditable = (fileName) => {
+  if (!fileName) return false;
+  const ext = fileName.split('.').pop().toLowerCase();
+  return EDITABLE_EXTENSIONS.has(ext);
+};
+
+// Simple syntax-theme map for textarea background cue (no heavy dep needed)
+const LANG_LABEL = {
+  html: 'HTML', htm: 'HTML', md: 'Markdown', txt: 'Plain Text',
+  js: 'JavaScript', jsx: 'JSX', ts: 'TypeScript', tsx: 'TSX',
+  css: 'CSS', scss: 'SCSS', less: 'LESS',
+  json: 'JSON', xml: 'XML', yaml: 'YAML', yml: 'YAML', csv: 'CSV',
+  java: 'Java', py: 'Python', rb: 'Ruby', php: 'PHP', sh: 'Shell',
+  c: 'C', cpp: 'C++', go: 'Go', rs: 'Rust', swift: 'Swift',
+};
+
+const FileEditModal = ({ file, onClose, onSaved }) => {
+  const { config, loading: configLoading } = useConfig();
+  const [content, setContent] = useState('');
+  const [originalContent, setOriginalContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const textareaRef = useRef(null);
+
+  const fileExt = file?.name ? file.name.split('.').pop().toLowerCase() : '';
+  const langLabel = LANG_LABEL[fileExt] || fileExt.toUpperCase();
+  const hasChanges = content !== originalContent;
+
+  // Construct absolute URL for fetching content
+  const getFullUrl = useCallback((targetUrl) => {
+    if (!targetUrl) return '';
+    if (targetUrl.startsWith('http')) return targetUrl;
+    if (!config?.backend_url) return targetUrl;
+    const base = config.backend_url.endsWith('/') ? config.backend_url.slice(0, -1) : config.backend_url;
+    const p = targetUrl.startsWith('/') ? targetUrl : `/${targetUrl}`;
+    return `${base}${p}`;
+  }, [config]);
+
+  // Load file content on mount
+  useEffect(() => {
+    if (configLoading || !file) return;
+    let cancelled = false;
+
+    const loadContent = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const rawUrl = file.downloadUrl || (file._id ? `/api/v1/files/${file._id}` : file.url);
+        const u = new URL(getFullUrl(rawUrl));
+        u.searchParams.set('preview', 'true');
+        const text = await fileApi.getFileContent(u.toString());
+        if (!cancelled) {
+          setContent(text);
+          setOriginalContent(text);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Failed to load file content');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    loadContent();
+    return () => { cancelled = true; };
+  }, [file, configLoading, getFullUrl]);
+
+  // Tab → insert 2 spaces
+  const handleKeyDown = (e) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const ta = textareaRef.current;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const next = content.substring(0, start) + '  ' + content.substring(end);
+      setContent(next);
+      requestAnimationFrame(() => {
+        ta.selectionStart = ta.selectionEnd = start + 2;
+      });
+    }
+    // Ctrl/Cmd + S → save
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  const handleSave = async () => {
+    if (!file?._id || saving) return;
+    setSaving(true);
+    try {
+      const response = await fileApi.updateFileContent(file._id, content);
+      if (response?.success) {
+        setOriginalContent(content);
+        toast.success('File saved successfully');
+        if (onSaved) onSaved({ ...file, size: response.data?.size });
+      } else {
+        throw new Error(response?.message || 'Save failed');
+      }
+    } catch (err) {
+      const msg = typeof err === 'string' ? err : err?.message || 'Failed to save file';
+      toast.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (hasChanges) {
+      if (!window.confirm('You have unsaved changes. Discard and close?')) return;
+    }
+    onClose();
+  };
+
+  // Keyboard shortcut: Escape → close (only when no unsaved changes)
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape' && !hasChanges) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [hasChanges, onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[1002] flex flex-col bg-black bg-opacity-70 backdrop-blur-sm">
+      <div className="flex flex-col bg-gray-950 w-full h-full max-h-screen">
+
+        {/* ── Header ── */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gray-900 border-b border-gray-700 flex-shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <span className="text-xl">✏️</span>
+            <div className="min-w-0">
+              <h2
+                className="text-sm font-bold text-white truncate max-w-xs md:max-w-lg"
+                title={file?.name}
+              >
+                {file?.name}
+              </h2>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-[10px] uppercase tracking-widest text-blue-400 font-semibold bg-blue-900/40 px-1.5 py-0.5 rounded">
+                  {langLabel}
+                </span>
+                {hasChanges && (
+                  <span className="text-[10px] text-yellow-400 font-medium">● Unsaved changes</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Save button */}
+            <button
+              onClick={handleSave}
+              disabled={saving || loading || !hasChanges}
+              className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-semibold rounded-lg transition
+                bg-blue-600 hover:bg-blue-500 text-white
+                disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {saving ? (
+                <>
+                  <span className="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                <>💾 Save</>
+              )}
+            </button>
+
+            {/* Close button */}
+            <button
+              onClick={handleClose}
+              className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition"
+              title="Close (Esc)"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* ── Status bar ── */}
+        <div className="flex items-center gap-4 px-4 py-1 bg-gray-900/80 border-b border-gray-800 text-[11px] text-gray-500 flex-shrink-0">
+          <span>{content.split('\n').length} lines</span>
+          <span>{content.length} chars</span>
+          <span className="ml-auto">Tab: 2 spaces &nbsp;·&nbsp; Ctrl+S to save &nbsp;·&nbsp; Esc to close</span>
+        </div>
+
+        {/* ── Editor body ── */}
+        <div className="flex-1 overflow-hidden relative">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center h-full text-gray-400">
+              <div className="w-10 h-10 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mb-4" />
+              <p className="text-sm font-medium">Loading file…</p>
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+              <span className="text-4xl mb-4">⚠️</span>
+              <p className="text-red-400 font-semibold text-sm mb-2">{error}</p>
+              <p className="text-gray-500 text-xs">Only local-disk files can be edited in the browser.</p>
+            </div>
+          ) : (
+            <textarea
+              ref={textareaRef}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onKeyDown={handleKeyDown}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              className="w-full h-full resize-none bg-gray-950 text-gray-100 font-mono text-sm
+                leading-relaxed p-4 focus:outline-none caret-blue-400
+                selection:bg-blue-600/50"
+              style={{ tabSize: 2 }}
+              autoFocus
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FileEditModal;

--- a/frontend/src/pages/components/editor/FilePreviewModal.jsx
+++ b/frontend/src/pages/components/editor/FilePreviewModal.jsx
@@ -1,0 +1,207 @@
+import React, { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import useConfig from '../../../hooks/useConfig';
+import fileApi from '../../../services/api/fileApi';
+
+const FilePreviewModal = ({ file, onClose }) => {
+  const { config, loading: configLoading } = useConfig();
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fileExt = file.name ? file.name.split('.').pop().toLowerCase() : '';
+  
+  // Construct absolute URL
+  const getFullUrl = (targetUrl) => {
+    if (!targetUrl) return '';
+    if (targetUrl.startsWith('http')) return targetUrl;
+    
+    // Fallback to relative URL if no config yet
+    if (!config?.backend_url) return targetUrl;
+
+    const baseUrl = config.backend_url;
+    const cleanBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const cleanPath = targetUrl.startsWith('/') ? targetUrl : `/${targetUrl}`;
+    
+    return `${cleanBase}${cleanPath}`;
+  };
+
+  const mainUrl = getFullUrl(file.url);
+  // Add ?preview=true to download URL for inline disposition
+  const rawDownloadUrl = file.downloadUrl || (file._id ? `/api/v1/files/${file._id}` : file.url);
+  const downloadUrl = getFullUrl(rawDownloadUrl) + (rawDownloadUrl.includes('?') ? '&' : '?') + 'preview=true';
+
+  useEffect(() => {
+    const isTextBased = ['html', 'md', 'txt', 'js', 'css', 'json'].includes(fileExt);
+    
+    if (isTextBased && downloadUrl && !configLoading) {
+      fetchContent();
+    }
+  }, [file, downloadUrl, configLoading]);
+
+  const fetchContent = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const text = await fileApi.getFileContent(downloadUrl);
+      setContent(text);
+    } catch (err) {
+      console.error('FilePreviewModal: Error fetching file content:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderPreview = () => {
+    if (loading) {
+      return (
+        <div className="flex flex-col items-center justify-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mb-4"></div>
+          <p className="text-gray-500 font-medium">Loading preview...</p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="flex flex-col items-center justify-center h-64 text-red-500 text-center p-4">
+          <span className="text-4xl mb-4">⚠️</span>
+          <p className="font-semibold">{error}</p>
+          <p className="text-sm mt-2 text-gray-500">Try downloading the file instead.</p>
+        </div>
+      );
+    }
+
+    // Images
+    if (['jpg', 'jpeg', 'png', 'gif', 'svg'].includes(fileExt)) {
+      return (
+        <div className="flex items-center justify-center p-4 bg-gray-50 rounded-lg overflow-auto max-h-[70vh]">
+          <img 
+            src={mainUrl} 
+            alt={file.name} 
+            className="max-w-full h-auto shadow-sm rounded border border-gray-200"
+            onError={(e) => {
+              if (e.target.src !== downloadUrl) {
+                e.target.src = downloadUrl;
+              }
+            }}
+          />
+        </div>
+      );
+    }
+
+    // PDF
+    if (fileExt === 'pdf') {
+      return (
+        <div className="w-full h-[70vh] border border-gray-200 rounded-lg overflow-hidden">
+          <iframe
+            src={`${downloadUrl}#toolbar=0`}
+            title={file.name}
+            className="w-full h-full"
+            frameBorder="0"
+          />
+        </div>
+      );
+    }
+
+    // HTML
+    if (fileExt === 'html') {
+      return (
+        <div className="w-full h-[70vh] border border-gray-200 rounded-lg overflow-hidden bg-white">
+          <iframe
+            srcDoc={content || ''}
+            title={file.name}
+            className="w-full h-full"
+            frameBorder="0"
+          />
+        </div>
+      );
+    }
+
+    // Markdown
+    if (fileExt === 'md') {
+      return (
+        <div className="prose prose-blue prose-sm sm:prose-base max-w-none p-6 bg-white border border-gray-200 rounded-lg overflow-y-auto max-h-[70vh] text-left">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {content || ''}
+          </ReactMarkdown>
+        </div>
+      );
+    }
+
+    // Other Text
+    if (['txt', 'js', 'css', 'json'].includes(fileExt)) {
+      return (
+        <div className="p-4 bg-gray-900 rounded-lg overflow-y-auto max-h-[70vh] text-left">
+          <pre className="text-blue-400 font-mono text-sm whitespace-pre-wrap">
+            {content || ''}
+          </pre>
+        </div>
+      );
+    }
+
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500 font-medium">Preview not available for this file type.</p>
+        <p className="text-xs text-gray-400 mt-2 uppercase tracking-widest">{fileExt}</p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[1001] flex items-center justify-center p-4 bg-black bg-opacity-60 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-5xl flex flex-col max-h-[90vh]">
+        {/* Modal Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-gray-50 rounded-t-2xl">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">📄</span>
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 truncate max-w-md" title={file.name}>
+                {file.name}
+              </h2>
+              <p className="text-xs text-gray-500 uppercase tracking-wider font-bold">
+                {fileExt} file • {file.size ? (file.size / 1024).toFixed(1) + ' KB' : 'Unknown size'}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-200 rounded-full transition text-gray-500 hover:text-gray-800"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Modal Content */}
+        <div className="p-6 overflow-y-auto flex-1 bg-white">
+          {renderPreview()}
+        </div>
+
+        {/* Modal Footer */}
+        <div className="px-6 py-4 border-t border-gray-100 bg-gray-50 rounded-b-2xl flex justify-end gap-3">
+          <a
+            href={downloadUrl.replace('preview=true', 'download=true')}
+            target="_blank"
+            download={file.name}
+            rel="noreferrer"
+            className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition shadow-md flex items-center gap-2"
+          >
+            <span>📥</span> Download Original
+          </a>
+          <button
+            onClick={onClose}
+            className="px-6 py-2 bg-white border border-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 transition"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FilePreviewModal;

--- a/frontend/src/pages/components/editor/FilePreviewModal.jsx
+++ b/frontend/src/pages/components/editor/FilePreviewModal.jsx
@@ -34,25 +34,28 @@ const FilePreviewModal = ({ file, onClose }) => {
 
   useEffect(() => {
     const isTextBased = ['html', 'md', 'txt', 'js', 'css', 'json'].includes(fileExt);
-    
-    if (isTextBased && downloadUrl && !configLoading) {
-      fetchContent();
-    }
-  }, [file, downloadUrl, configLoading]);
+    if (!isTextBased || !downloadUrl || configLoading) return;
 
-  const fetchContent = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const text = await fileApi.getFileContent(downloadUrl);
-      setContent(text);
-    } catch (err) {
-      console.error('FilePreviewModal: Error fetching file content:', err);
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+    let cancelled = false;
+
+    const fetchContent = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const text = await fileApi.getFileContent(downloadUrl);
+        if (!cancelled) setContent(text);
+      } catch (err) {
+        console.error('FilePreviewModal: Error fetching file content:', err);
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchContent();
+
+    return () => { cancelled = true; };
+  }, [file, fileExt, downloadUrl, configLoading]);
 
   const renderPreview = () => {
     if (loading) {
@@ -115,6 +118,7 @@ const FilePreviewModal = ({ file, onClose }) => {
             title={file.name}
             className="w-full h-full"
             frameBorder="0"
+            sandbox="allow-same-origin"
           />
         </div>
       );
@@ -184,7 +188,16 @@ const FilePreviewModal = ({ file, onClose }) => {
         {/* Modal Footer */}
         <div className="px-6 py-4 border-t border-gray-100 bg-gray-50 rounded-b-2xl flex justify-end gap-3">
           <a
-            href={downloadUrl.replace('preview=true', 'download=true')}
+            href={(() => {
+              try {
+                const u = new URL(downloadUrl);
+                u.searchParams.set('preview', 'false');
+                u.searchParams.set('download', 'true');
+                return u.toString();
+              } catch {
+                return downloadUrl;
+              }
+            })()}
             target="_blank"
             download={file.name}
             rel="noreferrer"

--- a/frontend/src/pages/components/editor/MobileMenu.jsx
+++ b/frontend/src/pages/components/editor/MobileMenu.jsx
@@ -26,6 +26,7 @@ import {
 } from '../../../assets/svgs';
 import { getPresizeFileName, generateRandomString } from '../../../common/functions';
 import useClickOutside from '../../../hooks/useClickOutside';
+import useConfig from '../../../hooks/useConfig';
 import toast from 'react-hot-toast';
 
 const isPreviewable = (fileName) => {
@@ -60,10 +61,23 @@ const MobileMenu = ({
   onTmpSlugSubmit,
   redirectArrowIcon
 }) => {
+  const { config } = useConfig();
   const mobileMenuRef = useRef(null);
   const [documentSearch, setDocumentSearch] = useState('');
   const [fileSearch, setFileSearch] = useState('');
   const [optimisticPages, setOptimisticPages] = useState(null);
+
+  // Helper to construct absolute URL
+  const getFullUrl = (targetUrl) => {
+    if (!targetUrl) return '';
+    if (targetUrl.startsWith('http')) return targetUrl;
+    
+    const baseUrl = config?.backend_url || '';
+    const cleanBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const cleanPath = targetUrl.startsWith('/') ? targetUrl : `/${targetUrl}`;
+    
+    return `${cleanBase}${cleanPath}`;
+  };
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -357,7 +371,7 @@ const MobileMenu = ({
                             </div>
                             <div className="flex gap-2 pt-2 border-t border-gray-100">
                               <a
-                                href={file.url}
+                                href={getFullUrl(file.downloadUrl || (file._id ? `/api/v1/files/${file._id}` : file.url))}
                                 target="_blank"
                                 download={file.name}
                                 rel="noreferrer"

--- a/frontend/src/pages/components/editor/MobileMenu.jsx
+++ b/frontend/src/pages/components/editor/MobileMenu.jsx
@@ -28,6 +28,12 @@ import { getPresizeFileName, generateRandomString } from '../../../common/functi
 import useClickOutside from '../../../hooks/useClickOutside';
 import toast from 'react-hot-toast';
 
+const isPreviewable = (fileName) => {
+  if (!fileName) return false;
+  const ext = fileName.split('.').pop().toLowerCase();
+  return ['jpg', 'jpeg', 'png', 'gif', 'svg', 'pdf', 'html', 'md', 'txt', 'js', 'css', 'json'].includes(ext);
+};
+
 /**
  * MobileMenu - Mobile dropdown menu (hamburger)
  * Shows pages/files navigation on mobile devices
@@ -43,6 +49,7 @@ const MobileMenu = ({
   onPageRemove,
   onSelectFile,
   onFileRemove,
+  onFilePreview,
   privateFileList,
   onPageRename,
   onPageReorder,
@@ -358,6 +365,17 @@ const MobileMenu = ({
                               >
                                 Download
                               </a>
+                              {isPreviewable(file.name) && (
+                                <button
+                                  onClick={() => {
+                                    onFilePreview(file);
+                                    onToggle(); // Close menu
+                                  }}
+                                  className="flex-1 px-3 py-2 text-xs bg-blue-50 text-blue-600 rounded-md font-medium"
+                                >
+                                  Preview
+                                </button>
+                              )}
                               <button
                                 onClick={() => onFileRemove(file)}
                                 className="px-3 py-2 text-xs bg-red-50 text-red-600 rounded-md font-medium"

--- a/frontend/src/pages/components/editor/MobileMenu.jsx
+++ b/frontend/src/pages/components/editor/MobileMenu.jsx
@@ -27,6 +27,7 @@ import {
 import { getPresizeFileName, generateRandomString } from '../../../common/functions';
 import useClickOutside from '../../../hooks/useClickOutside';
 import useConfig from '../../../hooks/useConfig';
+import { isEditable } from './FileEditModal';
 import toast from 'react-hot-toast';
 
 const isPreviewable = (fileName) => {
@@ -51,6 +52,7 @@ const MobileMenu = ({
   onSelectFile,
   onFileRemove,
   onFilePreview,
+  onFileEdit,
   privateFileList,
   onPageRename,
   onPageReorder,
@@ -383,11 +385,22 @@ const MobileMenu = ({
                                 <button
                                   onClick={() => {
                                     onFilePreview(file);
-                                    onToggle(); // Close menu
+                                    onToggle();
                                   }}
                                   className="flex-1 px-3 py-2 text-xs bg-blue-50 text-blue-600 rounded-md font-medium"
                                 >
                                   Preview
+                                </button>
+                              )}
+                              {file.storageMethod === 'local_disk' && isEditable(file.name) && (
+                                <button
+                                  onClick={() => {
+                                    onFileEdit(file);
+                                    onToggle();
+                                  }}
+                                  className="flex-1 px-3 py-2 text-xs bg-violet-50 text-violet-600 rounded-md font-medium"
+                                >
+                                  Edit
                                 </button>
                               )}
                               <button

--- a/frontend/src/services/api/fileApi.js
+++ b/frontend/src/services/api/fileApi.js
@@ -81,6 +81,28 @@ class FileApi {
   }
 
   /**
+   * Get raw file content (for previewing text-based files)
+   * @param {string} url - Absolute URL to fetch content from
+   */
+  async getFileContent(url) {
+    try {
+      const response = await fetch(url, {
+        credentials: 'include',
+        method: 'GET',
+      });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch file content: ${response.status} ${response.statusText}`);
+      }
+      
+      return await response.text();
+    } catch (error) {
+      console.error('FileApi: Error fetching file content:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Handle API errors
    */
   handleError(error) {

--- a/frontend/src/services/api/fileApi.js
+++ b/frontend/src/services/api/fileApi.js
@@ -103,6 +103,21 @@ class FileApi {
   }
 
   /**
+   * Update file content (local_disk text-based files only)
+   * @param {string} fileId - MongoDB file ID
+   * @param {string} content - New text content
+   */
+  async updateFileContent(fileId, content) {
+    try {
+      const response = await apiClient.put(`/api/v1/files/${fileId}/content`, { content });
+      return response;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+
+  /**
    * Handle API errors
    */
   handleError(error) {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,7 +2,10 @@ module.exports = {
     content: [
         './src/**/*.{js,jsx,ts,tsx,css}',
     ],
-    plugins: [require('flowbite/plugin')],
+    plugins: [
+        require('flowbite/plugin'),
+        require('@tailwindcss/typography'),
+    ],
     theme: {
       screens: {
         sm: '300px',

--- a/todo.md
+++ b/todo.md
@@ -6,8 +6,9 @@
     - [x] Add `local_disk` storage method to File model
     - [x] Create `LocalStorageService` with path fallback logic (`/home/ubuntu/...` -> `backend/public/...`)
     - [x] Update `fileController` to support local storage operations (upload, download/stream, delete)
-    - [x] Configure static route in `app.js` for file previews
-- [ ] Implement file preview in frontend (UI update)
+    - [x] Configure static route in `app.js` for file previews (route removed — all access authenticated via `/api/v1/files/:id`)
+- [x] Implement file preview in frontend (FilePreviewModal, EditorSidebar, MobileMenu)
+- [x] Implement file edit in browser (html, md, js, java, css etc) — FileEditModal + PUT /api/v1/files/:id/content
 - [ ] Add toggle in User Profile for `localFileUploadEnabled`
 
 ## Completed Tasks

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,16 @@
+# Project Tasks - CodeShare
+
+## Active Tasks
+- [x] Implement local file upload enhancement
+    - [x] Add `localFileUploadEnabled` to User model
+    - [x] Add `local_disk` storage method to File model
+    - [x] Create `LocalStorageService` with path fallback logic (`/home/ubuntu/...` -> `backend/public/...`)
+    - [x] Update `fileController` to support local storage operations (upload, download/stream, delete)
+    - [x] Configure static route in `app.js` for file previews
+- [ ] Implement file preview in frontend (UI update)
+- [ ] Add toggle in User Profile for `localFileUploadEnabled`
+
+## Completed Tasks
+- [x] Consolidate middleware files (Conversation 7051166b)
+- [x] Fix player image displays (Conversation efdee3cb)
+- [x] Refactor service tests (Conversation 71ea5d79)


### PR DESCRIPTION
## Summary

This PR implements local disk file storage as an alternative to Google Drive, adds browser-based file preview and editing, resolves all identified security vulnerabilities, and exposes document version history to public (non-logged-in) users.

---

## Changes

### 🔴 Critical Security Fixes
- **Removed unauthenticated static route** — `/uploads/codeshare` was publicly accessible without any auth; all file access now goes through the authenticated `GET /api/v1/files/:id` endpoint with ownership checks
- **Path traversal guard** — `downloadFile` and `updateFileContent` validate that `file.localPath` resolves within the uploads root before serving or writing
- **Eliminated double-save race condition** — `uploadFile` now pre-generates a `mongoose.Types.ObjectId` so `downloadUrl` is set in a single `save()` call

### 🟠 High Security Fixes
- **Auth middleware bug** — `isPublic` bypass now checks the resolved `token` variable instead of re-reading `req.cookies.token`, preventing Bearer-token requests with `isPublic:true` from being treated as anonymous
- **`localStorageService` crash safety** — lazy path caching, no startup throw on permission errors, `LOCAL_UPLOAD_PATH` env var support (removes hardcoded server path), async `fs.promises` I/O
- **Admin file count query** — `{ isDeleted: { $ne: true } }` replaces `{ isDeleted: false }` so older records without the field are counted correctly

### 🟡 Medium / Low Fixes
- **MIME type + extension allowlist** for local uploads — blocks `.php`, `.sh`, `.exe` etc. before any disk I/O
- **`FilePreviewModal` useEffect** — `fetchContent` moved inside the effect (no stale closure), `fileExt` added to dep array, cancellation on unmount
- **HTML preview iframe** — `sandbox="allow-same-origin"` blocks script execution from uploaded HTML files
- **Download URL construction** — replaced fragile `str.replace('preview=true')` with `URLSearchParams`
- Removed all `console.log` / emoji debug lines from production code paths in `fileController.js`

---

### ✨ New Feature — Local File Storage
- `LocalStorageService` with primary path (`LOCAL_UPLOAD_PATH` env var) and project-relative fallback
- `FileModel` extended with `storageMethod`, `localPath`, `localFileUploadEnabled` fields
- `uploadFile` / `downloadFile` / `deleteFile` in `fileController.js` support both `local_disk` and `google_drive`
- Authenticated streaming endpoint for local files with `Content-Disposition: inline` for previews

### ✨ New Feature — File Preview (`FilePreviewModal`)
- Supports images, PDF, HTML (sandboxed iframe), Markdown (react-markdown), plain text / code
- Fetches content via authenticated API (no public URL exposure)
- Download button uses proper `URLSearchParams` to swap `preview` ↔ `download` param

### ✨ New Feature — Browser File Edit (`FileEditModal`)
- Full-screen dark code editor for text-based local-disk files
- Editable extensions: `html`, `md`, `js`, `ts`, `jsx`, `css`, `json`, `java`, `py`, `rb`, `php`, `sh`, and more
- `Tab` → 2 spaces, `Ctrl/Cmd+S` to save, `Esc` to close
- Unsaved-change tracking with confirm-before-close
- `PUT /api/v1/files/:fileId/content` backend endpoint with path traversal guard + editable-extension allowlist
- **Edit** button (violet) shown in
